### PR TITLE
Cleanup and Bug Fixing

### DIFF
--- a/src/BankWithHtree.cpp
+++ b/src/BankWithHtree.cpp
@@ -178,10 +178,10 @@ void BankWithHtree::Initialize(int _numRowSubArray, int _numColumnSubArray, long
         numAddressBit = (int)(log2((double)capacity / blockSize / associativity) + 0.1);
     }
 
-	if (memoryType == data) {
+	if (memoryType == MemoryType::data) {
 		numDataDistributeBit = blockSize;
 		numDataBroadcastBit = (int)(log2(associativity));	/* TO-DO: this is not the only way */
-	} else if (memoryType == tag) {
+	} else if (memoryType == MemoryType::tag) {
 		numDataDistributeBit = associativity;		/* TO-DO: it seems that it only supports power of 2 here */
 		numDataBroadcastBit = blockSize;
 	} else {	/* CAM */
@@ -410,7 +410,7 @@ void BankWithHtree::Initialize(int _numRowSubArray, int _numColumnSubArray, long
 	}
 
 	/* If this subarray is cache data array, determine if the number of cache ways assigned to this subarray is legal */
-	if (memoryType == data) {
+	if (memoryType == MemoryType::data) {
 		if (numRowPerSet > (int)pow(2, numDataBroadcastBitToRoute)) {
 			/* There is no enough ways to distribute into multiple rows */
 			invalid = true;
@@ -420,7 +420,7 @@ void BankWithHtree::Initialize(int _numRowSubArray, int _numColumnSubArray, long
 	}
 
 	/* If this subarray is cache tag array, determine if the number of cache ways assigned to this subarray is legal */
-	if (memoryType == tag) {
+	if (memoryType == MemoryType::tag) {
 		if (numRowPerSet > 1) {
 			/* tag array cannot have multiple rows to contain ways in a set, otherwise the bitline has to be shared */
 			invalid = true;
@@ -437,7 +437,7 @@ void BankWithHtree::Initialize(int _numRowSubArray, int _numColumnSubArray, long
 
 	/* Determine the number of columns in a subarray */
 	long subarrayBlockSize;
-	if (memoryType == data) {		/* Data array */
+	if (memoryType == MemoryType::data) {		/* Data array */
 		/* numDataDistributeBit is the bits in a data word that is assigned to this subarray */
 		subarrayBlockSize = numDataDistributeBitToRoute;
 		numWay = (int)pow(2, numDataBroadcastBitToRoute);
@@ -463,7 +463,7 @@ void BankWithHtree::Initialize(int _numRowSubArray, int _numColumnSubArray, long
 				muxOutputLev2 *= extraMuxOutputLev2;
 			}
 		}
-	} else if (memoryType == tag) {	/* Tag array */
+	} else if (memoryType == MemoryType::tag) {	/* Tag array */
 		/* numDataBroadcastBit is the tag width, numDataDistributeBit is the number of ways assigned to this subarray */
 		subarrayBlockSize = numDataBroadcastBitToRoute;
 		numWay = numDataDistributeBitToRoute;
@@ -531,7 +531,7 @@ void BankWithHtree::CalculateArea() {
 		}
 
 		/* Determine if the aspect ratio meets the constraint */
-		if (memoryType == data)
+		if (memoryType == MemoryType::data)
 			if (height / width > CONSTRAINT_ASPECT_RATIO_BANK || width / height > CONSTRAINT_ASPECT_RATIO_BANK) {
 				/* illegal */
 				invalid = true;

--- a/src/BankWithoutHtree.cpp
+++ b/src/BankWithoutHtree.cpp
@@ -119,7 +119,7 @@ void BankWithoutHtree::Initialize(int _numRowSubArray, int _numColumnSubArray, l
 	numDataBitRouteToSubArray = blockSize;
 
 
-	if (memoryType == data) { /* Data array */
+	if (memoryType == MemoryType::data) { /* Data array */
 		numDataBitRouteToSubArray = blockSize / numActiveSubArrayPerColumn / numActiveSubArrayPerRow;
 		if (numRowPerSet > associativity) {
 			/* There is no enough ways to distribute into multiple rows */
@@ -149,7 +149,7 @@ void BankWithoutHtree::Initialize(int _numRowSubArray, int _numColumnSubArray, l
 				muxOutputLev2 *= extraMuxOutputLev2;
 			}
 		}
-	} else if (memoryType == tag) { /* Tag array */
+	} else if (memoryType == MemoryType::tag) { /* Tag array */
 		if (numRowPerSet > 1) {
 			/* tag array cannot have multiple rows to contain ways in a set, otherwise the bitline has to be shared */
 			invalid = true;
@@ -201,7 +201,7 @@ void BankWithoutHtree::Initialize(int _numRowSubArray, int _numColumnSubArray, l
 		}
 
 		int numSenseAmp;
-		if (memoryType == data)
+		if (memoryType == MemoryType::data)
 			numSenseAmp = blockSize;
 		else
 			numSenseAmp = blockSize * associativity;
@@ -216,7 +216,7 @@ void BankWithoutHtree::Initialize(int _numRowSubArray, int _numColumnSubArray, l
 		globalBitlineMux.Initialize(numRowSubArray * numColumnSubArray / numActiveSubArrayPerColumn / numActiveSubArrayPerRow, numSenseAmp, globalSenseAmp.capLoad, globalSenseAmp.capLoad, 0);
 		globalBitlineMux.CalculateRC();
 
-		if (memoryType == tag)
+		if (memoryType == MemoryType::tag)
 			globalComparator.Initialize(blockSize, 0 /* TO-DO: only for test */);
 	}
 
@@ -261,14 +261,14 @@ void BankWithoutHtree::CalculateArea() {
 			height += globalSenseAmp.height;
 			globalBitlineMux.CalculateArea();
 			height += globalBitlineMux.height;
-			if (memoryType == tag) {
+			if (memoryType == MemoryType::tag) {
 				globalComparator.CalculateArea();
 				height += associativity * globalComparator.area / width;
 			}
 		}
 
 		/* Determine if the aspect ratio meets the constraint */
-		if (memoryType == data)
+		if (memoryType == MemoryType::data)
 			if (height / width > CONSTRAINT_ASPECT_RATIO_BANK || width / height > CONSTRAINT_ASPECT_RATIO_BANK) {
 				/* illegal */
 				invalid = true;
@@ -310,7 +310,7 @@ void BankWithoutHtree::CalculateRC() {
 		if (!internalSenseAmp) {
 			globalBitlineMux.CalculateRC();
 			globalSenseAmp.CalculateRC();
-			if (memoryType == tag)
+			if (memoryType == MemoryType::tag)
 				globalComparator.CalculateRC();
 		}
 	}
@@ -349,7 +349,7 @@ void BankWithoutHtree::CalculateLatencyAndPower() {
                     refreshLatency += latency;
 				}
 				if (i < numActiveSubArrayPerColumn) {
-					if (memoryType == tag)
+					if (memoryType == MemoryType::tag)
 						numBitRouteToSubArray = numAddressBitRouteToSubArray + numDataBitRouteToSubArray + numWay;
 					else
 						numBitRouteToSubArray = numAddressBitRouteToSubArray + numDataBitRouteToSubArray;
@@ -453,7 +453,7 @@ void BankWithoutHtree::CalculateLatencyAndPower() {
 			readDynamicEnergy += (globalBitlineMux.readDynamicEnergy + globalSenseAmp.readDynamicEnergy) * numActiveSubArrayPerRow;
 			writeDynamicEnergy += (globalBitlineMux.writeDynamicEnergy + globalSenseAmp.writeDynamicEnergy) * numActiveSubArrayPerRow;
 			leakage += (globalBitlineMux.leakage + globalSenseAmp.leakage) * numColumnSubArray;
-			if (memoryType == tag) {
+			if (memoryType == MemoryType::tag) {
 				globalComparator.CalculateLatency(1e40);
 				readLatency += globalComparator.readLatency;
 				globalComparator.CalculatePower();

--- a/src/InputParameter.cpp
+++ b/src/InputParameter.cpp
@@ -175,6 +175,10 @@ void InputParameter::ReadInputParameterFromFile(const std::string & inputFile) {
 				optimizationTarget = read_edp_optimized;
 			else if (!strcmp(tmp, "WriteEDP"))
 				optimizationTarget = write_edp_optimized;
+			else if (!strcmp(tmp, "ReadBandwidth"))
+				optimizationTarget = read_bandwidth_optimized;
+			else if (!strcmp(tmp, "WriteBandwidth"))
+				optimizationTarget = write_bandwidth_optimized;
 			else if (!strcmp(tmp, "LeakagePower"))
 				optimizationTarget = leakage_optimized;
 			else if (!strcmp(tmp, "Area"))
@@ -770,6 +774,12 @@ void InputParameter::PrintInputParameter() {
 			break;
 		case write_edp_optimized:
 			cout << "write energy-delay-product ..." << endl;
+			break;
+		case read_bandwidth_optimized:
+			cout << "read bandwidth ..." << endl;
+			break;
+		case write_bandwidth_optimized:
+			cout << "write bandwidth ..." << endl;
 			break;
 		case leakage_optimized:
 			cout << "leakage power ..." << endl;

--- a/src/InputParameter.cpp
+++ b/src/InputParameter.cpp
@@ -474,7 +474,7 @@ void InputParameter::ReadInputParameterFromFile(const std::string & inputFile) {
 		}
 
 		if (!strncmp("-ClockFrequency", line, strlen("-ClockFrequency"))) {
-			sscanf(line, "-ClockFrequency: %d", &clockInput);
+			sscanf(line, "-ClockFrequency: %lf", &clockInput);
 			clockFreq = clockInput;
 			continue;
 		}
@@ -631,19 +631,19 @@ void InputParameter::ReadInputParameterFromFile(const std::string & inputFile) {
 		}
 
 		if (!strncmp("-ViewMatStatistics", line, strlen("-ViewMatStatistics"))) {
-			sscanf(line, "-ViewMatStatistics: %lf", tmp);
+			sscanf(line, "-ViewMatStatistics: %s", tmp);
 			viewMatStats = true;
 			continue;
 		}
 
-		if (!strncmp("-ViewQuantization", line, strlen("-VieQuantization"))) {
-			sscanf(line, "-ViewQuantization: %lf", tmp);
+		if (!strncmp("-ViewQuantization", line, strlen("-ViewQuantization"))) {
+			sscanf(line, "-ViewQuantization: %s", tmp);
 			quantize = true;
 			continue;
 		}
 
 		if (!strncmp("-M3DMemory", line, strlen("-M3DMemory"))) {
-			sscanf(line, "-M3DMemory: %lf", tmp);
+			sscanf(line, "-M3DMemory: %s", tmp);
 			monolithic3DMat = true;
 			continue;
 		}

--- a/src/InputParameter.h
+++ b/src/InputParameter.h
@@ -40,7 +40,7 @@ public:
 
 	/* Properties */
 	DesignTarget designTarget;		/* Cache, RAM, or CAM */
-	OptimizationTarget optimizationTarget;	/* Either read latency, write latency, read energy, write energy, leakage, or area */
+	OptimizationTarget optimizationTarget;	/* Either latency, energy, EDP, bandwidth, leakage, or area */
 	int processNode;				/* Process node (nm) */
 	int64_t capacity;				/* Memory/cache capacity, Unit: Byte */
 	long wordWidth;					/* The width of each input/output word, Unit: bit */

--- a/src/LeveShifter.cpp
+++ b/src/LeveShifter.cpp
@@ -199,6 +199,10 @@ void LevelShifter::CalculatePower(double activityRowRead) {
 }
 
 
+void LevelShifter::PrintProperty() {
+	PrintProperty("LevelShifter Properties:");
+}
+
 void LevelShifter::PrintProperty(const char* str) {
 	//cout << "LevelShifter Properties:" << endl;
 	cout << str << endl;

--- a/src/LevelShifter.h
+++ b/src/LevelShifter.h
@@ -63,6 +63,7 @@ public:
 	virtual ~LevelShifter();
 
 	/* Functions */
+	void PrintProperty();
 	void PrintProperty(const char* str);
 	void Initialize(int _numOutput, double _activityRowRead, double _writeVoltage, double _holdVoltage);
 	void CalculateArea(double _newHeight, double _newWidth, AreaModify _option);

--- a/src/Mat.cpp
+++ b/src/Mat.cpp
@@ -184,6 +184,7 @@ void Mat::Initialize(long long _numRow, long long _numColumn, bool _multipleRowP
 
 	double MIN_CELL_HEIGHT = MAX_TRANSISTOR_HEIGHT;  //set real layout cell height
 	double MIN_CELL_WIDTH = (MIN_GAP_BET_GATE_POLY + POLY_WIDTH) * 2;  //set real layout cell width
+	// NSCACHE_UNUSED_KEEP: retained from NeurSim 1.4 cell-relaxation geometry for future layout use.
 	double ISOLATION_REGION = MIN_POLY_EXT_DIFF*2 + MIN_GAP_BET_FIELD_POLY; // 1.4 update : new variable
 
 	/* Add cell relaxation parameters from NeurSim 1.4 */
@@ -224,6 +225,7 @@ void Mat::Initialize(long long _numRow, long long _numColumn, bool _multipleRowP
 			MIN_CELL_WIDTH  *= (CPP_1nm/(MIN_GAP_BET_GATE_POLY + POLY_WIDTH));
 			break;
 	}
+	(void)ISOLATION_REGION;
 
 	/* Derived parameters */
 	numSenseAmp = numColumn / muxSenseAmp;
@@ -824,9 +826,10 @@ void Mat::CalculateLatency(double _rampInput) {
 			double beta = 1 / (resPullDown * gm);
 			double bitlineRamp = 0;
 			// From NeuroSim - Elmore BL (from IDRS 2022: More Moore)
-			double BLCap_perCell = capBitline / numRow + capCellAccess; // Anni update
-			double BLRes_perCell = resBitline / numRow;
-			double Elmore_BL = (resCellAccess + resPullDown) * BLCap_perCell * numRow   + BLCap_perCell * BLRes_perCell * numRow  * ( numRow +1 )  /2;
+			// NSCACHE_UNUSED_KEEP: retained for the alternate Elmore bitline-delay path below.
+			// double BLCap_perCell = capBitline / numRow + capCellAccess; // Anni update
+			// double BLRes_perCell = resBitline / numRow;
+			// double Elmore_BL = (resCellAccess + resPullDown) * BLCap_perCell * numRow   + BLCap_perCell * BLRes_perCell * numRow  * ( numRow +1 )  /2;
 			//bitlineDelay = Elmore_BL * log(tech->vdd / (tech->vdd - cell->minSenseVoltage / 2));
 			bitlineDelay = horowitz(tau, beta, rowDecoder.rampOutput, &bitlineRamp);
 			bitlineMux.CalculateLatency(bitlineRamp);
@@ -1274,9 +1277,10 @@ void Mat::CalculateRepeater(int numCol){
 	double optEDP, currentEDP, currentEnergy, currentDelay;
 	double repeater_leakage;
 	double repeater_readDynamicEnergy;
-	double repeater_writeDynamicEnergy;
-	double repeater_readDynamicEnergyMux;
-	double repeater_writeDynamicEnergyMux;
+	// NSCACHE_UNUSED_KEEP: retained for future write/mux-aware repeater energy accounting.
+	// double repeater_writeDynamicEnergy;
+	// double repeater_readDynamicEnergyMux;
+	// double repeater_writeDynamicEnergyMux;
 	double sectionresLoc, sectioncapLoc, targetdriveresLoc, widthInvNLoc, widthInvPLoc;
 	double resPullDown;
 	double capLoad;

--- a/src/MemCell.cpp
+++ b/src/MemCell.cpp
@@ -72,6 +72,7 @@ MemCell::MemCell() {
 	resistanceOffAtHalfReadVoltage = 0;
 
     retentionTime = invalid_value;
+	temperature = 300;
 }
 
 MemCell::~MemCell() {
@@ -272,9 +273,9 @@ void MemCell::ReadCellFromFile(const string & inputFile)
 			continue;
 		}
 		if (!strncmp("-SetVoltage", line, strlen("-SetVoltage"))) {
-            sscanf(line, "-ResetVoltage (V): %s", tmp);
+            sscanf(line, "-SetVoltage (V): %s", tmp);
             if (!strcmp(tmp, "vdd"))
-                resetVoltage = tech->vdd;
+                setVoltage = tech->vdd;
             else
                 sscanf(line, "-SetVoltage (V): %lf", &setVoltage);
 			continue;
@@ -427,7 +428,7 @@ void MemCell::ReadCellFromFile(const string & inputFile)
 		}
 
 		if (!strncmp("-Temperature", line, strlen("-Temperature"))) {
-			if (memCellType != eDRAM || memCellType != gcDRAM)
+			if (memCellType != eDRAM && memCellType != gcDRAM)
 				cout << "Warning: The input of temperature is ignored because the cell is not eDRAM." << endl;
 			else
 				sscanf(line, "-Temperature (K): %lf", &temperature);

--- a/src/OutputDriver.cpp
+++ b/src/OutputDriver.cpp
@@ -35,7 +35,8 @@ void OutputDriver::Initialize(double _logicEffort, double _inputCap, double _out
 	addRepeaters = _addRepeaters;
 	wireLength = _wireLength;
 
-	double sizingfactor_MUX = 1;
+	// NSCACHE_UNUSED_KEEP: retained for possible mux-aware driver sizing.
+	// double sizingfactor_MUX = 1;
 	
 	double minNMOSDriverWidth = minDriverCurrent / tech->currentOnNmos[inputParameter->temperature - 300];
 	minNMOSDriverWidth = MAX(MIN_NMOS_SIZE * tech->featureSize, minNMOSDriverWidth);

--- a/src/OutputDriver.cpp
+++ b/src/OutputDriver.cpp
@@ -33,7 +33,7 @@ void OutputDriver::Initialize(double _logicEffort, double _inputCap, double _out
 	areaOptimizationLevel = _areaOptimizationLevel;
 	minDriverCurrent = _minDriverCurrent;
 	addRepeaters = _addRepeaters;
-	wireLength - _wireLength;
+	wireLength = _wireLength;
 
 	double sizingfactor_MUX = 1;
 	

--- a/src/Result.cpp
+++ b/src/Result.cpp
@@ -53,6 +53,8 @@ Result::Result() {
 	limitWriteDynamicEnergy = invalid_value;
 	limitReadEdp = invalid_value;
 	limitWriteEdp = invalid_value;
+	limitReadBandwidth = invalid_value_min;
+	limitWriteBandwidth = invalid_value_min;
 	limitArea = invalid_value;
 	limitLeakage = invalid_value;
 
@@ -83,6 +85,33 @@ void Result::reset() {
 	bank->area = invalid_value;
 }
 
+double Result::getReadBandwidth() const {
+	if (bank->readLatency >= invalid_value / 10 || bank->blockSize <= 0)
+		return 0;
+
+	double readCycleLatency = bank->subarray.mat.readLatency - bank->subarray.mat.rowDecoder.readLatency
+			+ bank->subarray.mat.precharger.readLatency;
+	if (cell && cell->memCellType == gcDRAM) {
+		readCycleLatency = bank->subarray.mat.readLatency - bank->subarray.mat.gcRowDecoder.readLatency
+				+ bank->subarray.mat.precharger.readLatency;
+	}
+	if (readCycleLatency <= 0 || readCycleLatency >= invalid_value / 10)
+		return 0;
+
+	return (double)bank->blockSize / readCycleLatency / 8;
+}
+
+double Result::getWriteBandwidth() const {
+	if (bank->writeLatency >= invalid_value / 10 || bank->blockSize <= 0)
+		return 0;
+
+	double writeCycleLatency = bank->subarray.mat.writeLatency;
+	if (writeCycleLatency <= 0 || writeCycleLatency >= invalid_value / 10)
+		return 0;
+
+	return (double)bank->blockSize / writeCycleLatency / 8;
+}
+
 bool Result::compareAndUpdate(Result &newResult) {
     bool toUpdate = false;
 
@@ -90,6 +119,8 @@ bool Result::compareAndUpdate(Result &newResult) {
 			&& newResult.bank->readDynamicEnergy <= limitReadDynamicEnergy && newResult.bank->writeDynamicEnergy <= limitWriteDynamicEnergy
 			&& newResult.bank->readLatency * newResult.bank->readDynamicEnergy <= limitReadEdp
 			&& newResult.bank->writeLatency * newResult.bank->writeDynamicEnergy <= limitWriteEdp
+			&& newResult.getReadBandwidth() >= limitReadBandwidth
+			&& newResult.getWriteBandwidth() >= limitWriteBandwidth
 			&& newResult.bank->area <= limitArea && newResult.bank->leakage <= limitLeakage) {
 		switch (optimizationTarget) {
 		case read_latency_optimized:
@@ -114,6 +145,14 @@ bool Result::compareAndUpdate(Result &newResult) {
 			break;
 		case write_edp_optimized:
 			if 	(newResult.bank->writeLatency * newResult.bank->writeDynamicEnergy < bank->writeLatency * bank->writeDynamicEnergy)
+				toUpdate = true;
+			break;
+		case read_bandwidth_optimized:
+			if 	(newResult.getReadBandwidth() > getReadBandwidth())
+				toUpdate = true;
+			break;
+		case write_bandwidth_optimized:
+			if 	(newResult.getWriteBandwidth() > getWriteBandwidth())
 				toUpdate = true;
 			break;
 		case area_optimized:
@@ -159,6 +198,12 @@ string Result::printOptimizationTarget() {
         break;
     case write_edp_optimized:
         rv = "Write Energy-Delay-Product";
+        break;
+    case read_bandwidth_optimized:
+        rv = "Read Bandwidth";
+        break;
+    case write_bandwidth_optimized:
+        rv = "Write Bandwidth";
         break;
     case area_optimized:
         rv = "Area";
@@ -423,7 +468,7 @@ void Result::print(int indent) {
 	cout << string(indent, ' ') << "       |--- Mux Latency         = " << TO_SECOND(bank->subarray.mat.bitlineMux.readLatency
 													+ bank->subarray.mat.senseAmpMuxLev1.readLatency
 													+ bank->subarray.mat.senseAmpMuxLev2.readLatency) << endl;
-	if (bank->subarray.memoryType == tag && bank->subarray.internalSenseAmp)
+	if (bank->subarray.memoryType == MemoryType::tag && bank->subarray.internalSenseAmp)
 		cout << string(indent, ' ') << "    |--- Comparator Latency  = " << TO_SECOND(bank->subarray.comparator.readLatency) << endl;
 
 	if (cell->memCellType == PCRAM || cell->memCellType == FBRAM ||
@@ -518,19 +563,11 @@ void Result::print(int indent) {
 		cout << string(indent, ' ') << "    |--- Mat Latency   = " << TO_SECOND(bank->subarray.mat.refreshLatency) << endl;
     }
 
-	double readBandwidth = (double)bank->blockSize /
-			(bank->subarray.mat.readLatency - bank->subarray.mat.rowDecoder.readLatency
-			+ bank->subarray.mat.precharger.readLatency) / 8;
-	if (cell->memCellType == gcDRAM) {
-		readBandwidth = (double)bank->blockSize /
-			(bank->subarray.mat.readLatency - bank->subarray.mat.gcRowDecoder.readLatency
-			+ bank->subarray.mat.precharger.readLatency) / 8;
-	}
+	double readBandwidth = getReadBandwidth();
 	//cout << "DEBUGGING: bank blockSize - " << bank->blockSize << endl;
 	//cout << "DEBUGGING: mat readLatency - " << TO_SECOND(bank->subarray.mat.readLatency) << ", decoder readLatency - " << TO_SECOND(bank->subarray.mat.rowDecoder.readLatency) << ", precharger latency - " << TO_SECOND(bank->subarray.mat.precharger.readLatency) << endl;
 	cout << string(indent, ' ') << " - Read Bandwidth  = " << TO_BPS(readBandwidth) << endl;
-	double writeBandwidth = (double)bank->blockSize /
-			(bank->subarray.mat.writeLatency) / 8;
+	double writeBandwidth = getWriteBandwidth();
 	cout << string(indent, ' ') << " - Write Bandwidth = " << TO_BPS(writeBandwidth) << endl;
 
 	cout << string(indent, ' ') << "Power:" << endl;
@@ -992,7 +1029,7 @@ void Result::printToFile(int indent, const string &FileName) {
 	outFile << string(indent, ' ') << "       |--- Mux Latency         = " << TO_SECOND(bank->subarray.mat.bitlineMux.readLatency
 													+ bank->subarray.mat.senseAmpMuxLev1.readLatency
 													+ bank->subarray.mat.senseAmpMuxLev2.readLatency) << endl;
-	if (bank->subarray.memoryType == tag && bank->subarray.internalSenseAmp)
+	if (bank->subarray.memoryType == MemoryType::tag && bank->subarray.internalSenseAmp)
 		outFile << string(indent, ' ') << "    |--- Comparator Latency  = " << TO_SECOND(bank->subarray.comparator.readLatency) << endl;
 
 	if (cell->memCellType == PCRAM || cell->memCellType == FBRAM ||
@@ -1087,19 +1124,11 @@ void Result::printToFile(int indent, const string &FileName) {
 		outFile << string(indent, ' ') << "    |--- Mat Latency   = " << TO_SECOND(bank->subarray.mat.refreshLatency) << endl;
     }
 
-	double readBandwidth = (double)bank->blockSize /
-			(bank->subarray.mat.readLatency - bank->subarray.mat.rowDecoder.readLatency
-			+ bank->subarray.mat.precharger.readLatency) / 8;
-	if (cell->memCellType == gcDRAM) {
-		readBandwidth = (double)bank->blockSize /
-			(bank->subarray.mat.readLatency - bank->subarray.mat.gcRowDecoder.readLatency
-			+ bank->subarray.mat.precharger.readLatency) / 8;
-	}
+	double readBandwidth = getReadBandwidth();
 	//outFile << "DEBUGGING: bank blockSize - " << bank->blockSize << endl;
 	//outFile << "DEBUGGING: mat readLatency - " << TO_SECOND(bank->subarray.mat.readLatency) << ", decoder readLatency - " << TO_SECOND(bank->subarray.mat.rowDecoder.readLatency) << ", precharger latency - " << TO_SECOND(bank->subarray.mat.precharger.readLatency) << endl;
 	outFile << string(indent, ' ') << " - Read Bandwidth  = " << TO_BPS(readBandwidth) << endl;
-	double writeBandwidth = (double)bank->blockSize /
-			(bank->subarray.mat.writeLatency) / 8;
+	double writeBandwidth = getWriteBandwidth();
 	outFile << string(indent, ' ') << " - Write Bandwidth = " << TO_BPS(writeBandwidth) << endl;
 
 	outFile << string(indent, ' ') << "Power:" << endl;
@@ -1273,7 +1302,7 @@ void Result::printToFile(int indent, const string &FileName) {
 }
 
 void Result::printAsCache(Result &tagResult, CacheAccessMode cacheAccessMode) {
-	if (bank->memoryType != data || tagResult.bank->memoryType != tag) {
+	if (bank->memoryType != MemoryType::data || tagResult.bank->memoryType != MemoryType::tag) {
 		cout << "This is not a valid cache configuration." << endl;
 		return;
 	} else {
@@ -1453,7 +1482,7 @@ void Result::printAsCacheToFile(CacheAccessMode cacheAccessMode, const string &F
         return;
     }
 
-    if (bank->memoryType != data) {
+    if (bank->memoryType != MemoryType::data) {
         outFile << "This is not a valid cache configuration." << endl;
         outFile.close();
         return;
@@ -1751,7 +1780,7 @@ void Result::printToCsvFile(ofstream &outputFile) {
 }
 
 void Result::printAsCacheToCsvFile(Result &tagResult, CacheAccessMode cacheAccessMode, ofstream &outputFile) {
-	if (bank->memoryType != data || tagResult.bank->memoryType != tag) {
+	if (bank->memoryType != MemoryType::data || tagResult.bank->memoryType != MemoryType::tag) {
 		cout << "This is not a valid cache configuration." << endl;
 		return;
 	} else {

--- a/src/Result.cpp
+++ b/src/Result.cpp
@@ -1458,52 +1458,49 @@ void Result::printAsCacheToFile(CacheAccessMode cacheAccessMode, const string &F
         outFile.close();
         return;
     } else {
-        double cacheHitLatency, cacheMissLatency, cacheWriteLatency;
-        double cacheHitDynamicEnergy, cacheMissDynamicEnergy, cacheWriteDynamicEnergy;
-        double cacheLeakage;
-        double cacheArea;
+	    double cacheHitLatency = 0;
+	    double cacheMissLatency = 0;
+	    double cacheWriteLatency = 0;
+	    double cacheHitDynamicEnergy = 0;
+	    double cacheMissDynamicEnergy = 0;
+	    double cacheWriteDynamicEnergy = 0;
+	    double cacheLeakage = 0;
+	    double cacheArea = 0;
 
-        if (cacheAccessMode == normal_access_mode) {
-            // Calculate latencies
-            // cacheMissLatency = tagResult.bank->readLatency;  // only the tag access latency
-            cacheHitLatency =
-                bank->subarray.readLatency; // access tag and activate data row in parallel
-            cacheHitLatency += bank->subarray.mat.columnDecoderLatency;  // add column decoder latency after hit
-            cacheHitLatency += bank->readLatency - bank->subarray.readLatency; // H-tree in and out latency
-            cacheWriteLatency = bank->writeLatency; // Data and tag are written in parallel
+	    if (cacheAccessMode == normal_access_mode) {
+	        // Calculate latencies
+	        cacheHitLatency = bank->subarray.readLatency;
+	        cacheHitLatency += bank->subarray.mat.columnDecoderLatency;  // add column decoder latency after hit
+	        cacheHitLatency += bank->readLatency - bank->subarray.readLatency; // H-tree in and out latency
+	        cacheWriteLatency = bank->writeLatency;
 
-            // Calculate power
-            //cacheMissDynamicEnergy = tagResult.bank->readDynamicEnergy; // no subarrayter what tag is always accessed
-            cacheMissDynamicEnergy += bank->readDynamicEnergy;          // data is also partially accessed
-            cacheHitDynamicEnergy = bank->readDynamicEnergy;
-            cacheWriteDynamicEnergy = bank->writeDynamicEnergy;
-        } else if (cacheAccessMode == fast_access_mode) {
-            // Calculate latencies
-            // cacheMissLatency = tagResult.bank->readLatency;
-            cacheHitLatency = bank->readLatency;
-            cacheWriteLatency = bank->writeLatency;
+	        // Calculate power
+	        cacheMissDynamicEnergy += bank->readDynamicEnergy;          // data is also partially accessed
+	        cacheHitDynamicEnergy = bank->readDynamicEnergy;
+	        cacheWriteDynamicEnergy = bank->writeDynamicEnergy;
+	    } else if (cacheAccessMode == fast_access_mode) {
+	        // Calculate latencies
+	        cacheHitLatency = bank->readLatency;
+	        cacheWriteLatency = bank->writeLatency;
 
-            // Calculate power
-            // cacheMissDynamicEnergy = tagResult.bank->readDynamicEnergy; // no subarrayter what tag is always accessed
-            cacheMissDynamicEnergy += bank->readDynamicEnergy;          // data is also partially accessed
-            cacheHitDynamicEnergy = bank->readDynamicEnergy;
-            cacheWriteDynamicEnergy = bank->writeDynamicEnergy;
-        } else { // sequential access
-            // Calculate latencies
-            // cacheMissLatency = tagResult.bank->readLatency;
-            cacheHitLatency = bank->readLatency;
-            cacheWriteLatency =bank->writeLatency;
+	        // Calculate power
+	        cacheMissDynamicEnergy += bank->readDynamicEnergy;          // data is also partially accessed
+	        cacheHitDynamicEnergy = bank->readDynamicEnergy;
+	        cacheWriteDynamicEnergy = bank->writeDynamicEnergy;
+	    } else { // sequential access
+	        // Calculate latencies
+	        cacheHitLatency = bank->readLatency;
+	        cacheWriteLatency = bank->writeLatency;
 
-            // Calculate power
-            //cacheMissDynamicEnergy = tagResult.bank->readDynamicEnergy; // no subarrayter what tag is always accessed
-            cacheHitDynamicEnergy = bank->readDynamicEnergy;
-            cacheWriteDynamicEnergy = bank->writeDynamicEnergy;
-        }
+	        // Calculate power
+	        cacheHitDynamicEnergy = bank->readDynamicEnergy;
+	        cacheWriteDynamicEnergy = bank->writeDynamicEnergy;
+	    }
 
-        // Calculate leakage
-        // cacheLeakage = tagResult.bank->leakage + bank->leakage;
-        // Calculate area
-        cacheArea = bank->area;  // Just add them
+	    // Calculate leakage
+	    cacheLeakage = bank->leakage;
+	    // Calculate area
+	    cacheArea = bank->area;
 
         // Now write to the file instead of the console
         outFile << endl
@@ -1527,8 +1524,6 @@ void Result::printAsCacheToFile(CacheAccessMode cacheAccessMode, const string &F
         outFile << " - Total Area = " << cacheArea * 1e6 << "mm^2" << endl;
         outFile << " |--- Data Array Area = " << bank->height * 1e6 << "um x "
                 << bank->width * 1e6 << "um = " << bank->area * 1e6 << "mm^2" << endl;
-        //outFile << " |--- Tag Array Area  = " << tagResult.bank->height * 1e6 << "um x "
-        //        << tagResult.bank->width * 1e6 << "um = " << tagResult.bank->area * 1e6 << "mm^2" << endl;
 
         // Timing
         outFile << "Timing:" << endl;
@@ -1546,14 +1541,14 @@ void Result::printAsCacheToFile(CacheAccessMode cacheAccessMode, const string &F
 			outFile << " - Cache Data Mat Write Cycles = " << ceil(bank->subarray.mat.writeLatency * inputParameter->clockFreq) << " cycles" << endl;
 		}
         if (cell->memCellType == eDRAM || cell->memCellType == gcDRAM) {
-            outFile << " - Cache Refresh Latency = "
-                    << bank->refreshLatency * 1e6
-                    << "us per bank" << endl;
-            outFile << " - Cache Availability = "
-                    << ((cell->retentionTime -
-                         bank->refreshLatency) /
-                        cell->retentionTime) *
-                           100.0
+	        outFile << " - Cache Refresh Latency = "
+	                << bank->refreshLatency * 1e6
+	                << "us per bank" << endl;
+	        outFile << " - Cache Availability = "
+	                << ((cell->retentionTime -
+	                     bank->refreshLatency) /
+	                    cell->retentionTime) *
+	                       100.0
                     << "%" << endl;
         }
 
@@ -1565,15 +1560,13 @@ void Result::printAsCacheToFile(CacheAccessMode cacheAccessMode, const string &F
                 << "nJ per access" << endl;
         outFile << " - Cache Write Dynamic Energy = " << cacheWriteDynamicEnergy * 1e9
                 << "nJ per access" << endl;
-        if (cell->memCellType == eDRAM || cell->memCellType == gcDRAM) {
-            outFile << " - Cache Refresh Dynamic Energy = "
-                    << (bank->refreshDynamicEnergy) * 1e9
-                    << "nJ per bank" << endl;
-        }
-        outFile << " - Cache Total Leakage Power  = " << cacheLeakage * 1e3 << "mW" << endl;
-        outFile << " |--- Cache Data Array Leakage Power = " << bank->leakage * 1e3 << "mW" << endl;
-        //outFile << " |--- Cache Tag Array Leakage Power  = "
-        //        << tagResult.bank->leakage * 1e3 << "mW" << endl;
+	    if (cell->memCellType == eDRAM || cell->memCellType == gcDRAM) {
+	        outFile << " - Cache Refresh Dynamic Energy = "
+	                << (bank->refreshDynamicEnergy) * 1e9
+	                << "nJ per bank" << endl;
+	    }
+	    outFile << " - Cache Total Leakage Power  = " << cacheLeakage * 1e3 << "mW" << endl;
+	    outFile << " |--- Cache Data Array Leakage Power = " << bank->leakage * 1e3 << "mW" << endl;
         if (cell->memCellType == eDRAM || cell->memCellType == gcDRAM) {
             outFile << " - Cache Refresh Power = "
                     << TO_WATT(bank->refreshDynamicEnergy / (cell->retentionTime))

--- a/src/Result.h
+++ b/src/Result.h
@@ -39,6 +39,8 @@ public:
 	void printToCsvFile(ofstream &outputFile);
 	void printAsCacheToCsvFile(Result &tagBank, CacheAccessMode cacheAccessMode, ofstream &outputFile);
 	bool compareAndUpdate(Result &newResult);
+	double getReadBandwidth() const;
+	double getWriteBandwidth() const;
     string printOptimizationTarget();
 
 	OptimizationTarget optimizationTarget;	/* Exploration should not be assigned here */
@@ -53,6 +55,8 @@ public:
 	double limitWriteDynamicEnergy;		/* The maximum allowable write dynamic energy, Unit: J */
 	double limitReadEdp;				/* The maximum allowable read EDP, Unit: s-J */
 	double limitWriteEdp;				/* The maximum allowable write EDP, Unit: s-J */
+	double limitReadBandwidth;			/* The minimum allowable read bandwidth, Unit: B/s */
+	double limitWriteBandwidth;			/* The minimum allowable write bandwidth, Unit: B/s */
 	double limitArea;					/* The maximum allowable area, Unit: m^2 */
 	double limitLeakage;				/* The maximum allowable leakage power, Unit: W */
     MemCell *cellTech;

--- a/src/SubArray.cpp
+++ b/src/SubArray.cpp
@@ -85,7 +85,7 @@ void SubArray::Initialize(int _numRowMat, int _numColumnMat, int _numAddressBit,
 
 	/* Determine the number of rows in a mat */
 	numRow = 1 << _numAddressBit;
-	if (memoryType == data)
+	if (memoryType == MemoryType::data)
 		numRow *= numWay;	/* Only for cache design that partitions a set into multiple rows */
 	numRow /= (muxSenseAmp * muxOutputLev1 * muxOutputLev2);	/* Distribute to column decoding */
 	if (numRow == 0) {
@@ -102,7 +102,7 @@ void SubArray::Initialize(int _numRowMat, int _numColumnMat, int _numAddressBit,
 	}
 
 	numColumn *= muxSenseAmp * muxOutputLev1 * muxOutputLev2;
-	if (memoryType == tag)
+	if (memoryType == MemoryType::tag)
 		numColumn *= numWay;
 
 	mat.Initialize(numRow, numColumn, numRowPerSet > 1, true /* TO-DO: need to correct */,
@@ -173,7 +173,7 @@ void SubArray::Initialize(int _numRowMat, int _numColumnMat, int _numAddressBit,
     totalPredecoderOutputBits += 1 << numAddressSenseAmpMuxLev2PredecoderBlock1; 
     totalPredecoderOutputBits += 1 << numAddressSenseAmpMuxLev2PredecoderBlock2; 
 
-	if (memoryType == tag && internalSenseAmp) {
+	if (memoryType == MemoryType::tag && internalSenseAmp) {
 		comparator.Initialize(numDataBit, 0 /*TO-DO: need to fix */);
 	}
 
@@ -234,7 +234,7 @@ void SubArray::CalculateArea() {
                 height += sqrt(areaAllPredecoderBlocks);
         }
 
-		if (memoryType == tag && internalSenseAmp) {
+		if (memoryType == MemoryType::tag && internalSenseAmp) {
 			comparator.CalculateArea();
             areaAllLogicBlocks += comparator.area;
             // TSVs for comparator are added above in previous conditional
@@ -260,7 +260,7 @@ void SubArray::CalculateRC() {
 		senseAmpMuxLev1PredecoderBlock2.CalculateRC();
 		senseAmpMuxLev2PredecoderBlock1.CalculateRC();
 		senseAmpMuxLev2PredecoderBlock2.CalculateRC();
-		if (memoryType == tag && internalSenseAmp) {
+		if (memoryType == MemoryType::tag && internalSenseAmp) {
 			comparator.CalculateRC();
 		}
 	}
@@ -325,7 +325,7 @@ void SubArray::CalculateLatency(double _rampInput) {
         refreshLatency = predecoderLatency + mat.refreshLatency;
         refreshLatency *= numColumnMat; // TOTAL refresh time for all mats
 
-		if (memoryType == tag && internalSenseAmp) {
+		if (memoryType == MemoryType::tag && internalSenseAmp) {
 			comparator.CalculateLatency(_rampInput);
 			readLatency += comparator.readLatency;
 		}
@@ -388,7 +388,7 @@ void SubArray::CalculatePower() {
             leakage += tsvArray.numTotalBits * (stackedDieCount-1) * tsvArray.leakage;
         }
 
-		if (memoryType == tag && internalSenseAmp) {
+		if (memoryType == MemoryType::tag && internalSenseAmp) {
 			comparator.CalculatePower();
 			readDynamicEnergy += comparator.readDynamicEnergy * numWay;
 			writeDynamicEnergy += comparator.writeDynamicEnergy * numWay;
@@ -452,7 +452,7 @@ SubArray & SubArray::operator=(const SubArray &rhs) {
 	senseAmpMuxLev1PredecoderBlock2 = rhs.senseAmpMuxLev1PredecoderBlock2;
 	senseAmpMuxLev2PredecoderBlock1 = rhs.senseAmpMuxLev2PredecoderBlock1;
 	senseAmpMuxLev2PredecoderBlock2 = rhs.senseAmpMuxLev2PredecoderBlock2;
-	if (memoryType == tag && internalSenseAmp)
+	if (memoryType == MemoryType::tag && internalSenseAmp)
 		comparator = rhs.comparator;
 
     tsvArray = rhs.tsvArray;

--- a/src/TSV.cpp
+++ b/src/TSV.cpp
@@ -85,7 +85,8 @@ void TSV::CalculateArea()
     //Obtain the driver chain area and leakage power for TSV
     double Vdd = tech->vdd;
     double cumulative_area = 0;
-    double cumulative_curr = 0;  // cumulative leakage current
+    // NSCACHE_UNUSED_KEEP: retained for the old leakage-current path.
+    // double cumulative_curr = 0;  // cumulative leakage current
     double cumulative_curr_Ig = 0;  // cumulative leakage current
     buffer_area_height = 50 * tech->featureSize; // the assigned height for memory cell (5um), is it correct to use it here?
     double temperature = (double)inputParameter->temperature;
@@ -100,7 +101,7 @@ void TSV::CalculateArea()
 #ifdef NVSIM3DDEBUG
         cout << "\n\tArea up to the " << i+1 << " stages is: " << cumulative_area * 1e12 << " um2";
 #endif
-        cumulative_curr += CalculateGateLeakage(INV, 1, w_TSV_n[i], w_TSV_p[i], temperature, *tech);
+        // cumulative_curr += CalculateGateLeakage(INV, 1, w_TSV_n[i], w_TSV_p[i], temperature, *tech);
         // TODO -- What's the difference?
         cumulative_curr_Ig += CalculateGateLeakage(INV, 1, w_TSV_n[i], w_TSV_p[i], temperature, *tech);
     }
@@ -258,5 +259,4 @@ TSV& TSV::operator=(const TSV& rhs) {
 
     return *this;
 }
-
 

--- a/src/Technology.cpp
+++ b/src/Technology.cpp
@@ -47,6 +47,7 @@ void Technology::Initialize(int _featureSizeInNano, DeviceRoadmap _deviceRoadmap
 	featureSizeInNano = _featureSizeInNano;
 	featureSize = _featureSizeInNano * 1e-9;
 	deviceRoadmap = _deviceRoadmap;
+	vpp = 0;
 
 	if (_featureSizeInNano >= 180) { //TO-DO : only for test
 		if (_deviceRoadmap == HP) {
@@ -2456,6 +2457,10 @@ void Technology::Initialize(int _featureSizeInNano, DeviceRoadmap _deviceRoadmap
     /* For non-DRAM types vpp is equal to vdd. */
     if (_deviceRoadmap != EDRAM) {
         vpp = vdd;
+    } else if (vpp == 0) {
+        /* Advanced-node eDRAM has no separate table here; keep the legacy
+         * wordline boost offset instead of leaving vpp uninitialized. */
+        vpp = vdd + 0.5;
     }
 
 	if (_featureSizeInNano >= 22) {
@@ -2535,6 +2540,7 @@ void Technology::PrintProperty() {
 void Technology::InterpolateWith(Technology rhs, double _alpha) {
 	if (featureSizeInNano != rhs.featureSizeInNano) {
 		vdd = (1 - _alpha) * vdd + _alpha * rhs.vdd;
+		vpp = (1 - _alpha) * vpp + _alpha * rhs.vpp;
 		vth = (1 - _alpha) * vth + _alpha * rhs.vth;
 		phyGateLength = (1 - _alpha) * phyGateLength + _alpha * rhs.phyGateLength;
 		capIdealGate = (1 - _alpha) * capIdealGate + _alpha * rhs.capIdealGate;
@@ -2567,19 +2573,19 @@ void Technology::InterpolateWith(Technology rhs, double _alpha) {
 		vdsatPmos = phyGateLength * 1e5 /* Silicon saturatio velocity, Unit: m/s */ / effectiveHoleMobility;
 
 		// new technology parameters
-		max_sheet_num = max_sheet_num;
-		thickness_sheet = thickness_sheet;
-		width_sheet = width_sheet;
-		effective_width = effective_width;
-		max_fin_num = max_fin_num;
+		max_sheet_num = (1 - _alpha) * max_sheet_num + _alpha * rhs.max_sheet_num;
+		thickness_sheet = (1 - _alpha) * thickness_sheet + _alpha * rhs.thickness_sheet;
+		width_sheet = (1 - _alpha) * width_sheet + _alpha * rhs.width_sheet;
+		effective_width = (1 - _alpha) * effective_width + _alpha * rhs.effective_width;
+		max_fin_num = (1 - _alpha) * max_fin_num + _alpha * rhs.max_fin_num;
 		max_fin_per_GAA = rhs.max_fin_per_GAA;
 		gm_oncurrent = (1 - _alpha) * gm_oncurrent + _alpha * rhs.gm_oncurrent;  // gm at on current
 		cap_draintotal = (1 - _alpha) * cap_draintotal + _alpha * rhs.cap_draintotal;
 		current_gmNmos = (1 - _alpha) * current_gmNmos + _alpha * rhs.current_gmNmos;		/* NMOS current at 0.7*vdd for gm calculation, Unit: A/m/V*/ 
     	current_gmPmos = (1 - _alpha) * current_gmPmos + _alpha * rhs.current_gmPmos;		/* PMOS current at 0.7*vdd for gm calculation, Unit: A/m/V*/
-		heightFin = heightFin;	/* Fin height, Unit: m */
-		widthFin = widthFin;	/* Fin width, Unit: m */
-		PitchFin = PitchFin;	/* Fin pitch, Unit: m */
+		heightFin = (1 - _alpha) * heightFin + _alpha * rhs.heightFin;	/* Fin height, Unit: m */
+		widthFin = (1 - _alpha) * widthFin + _alpha * rhs.widthFin;	/* Fin width, Unit: m */
+		PitchFin = (1 - _alpha) * PitchFin + _alpha * rhs.PitchFin;	/* Fin pitch, Unit: m */
 	}
 }
 
@@ -2751,4 +2757,3 @@ void Technology::SetLayerCount(InputParameter *inputParameter, int layers)
 
     layerCount = layers;
 }
-

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -102,12 +102,14 @@ double CalculateGateArea(
     int maxNumPFin = 0, maxNumNFin = 0;	/* Max number of fins for the specified cell height */
     double unitWidthRegionP, unitWidthRegionN;
     double widthRegionP, widthRegionN;
+    // NSCACHE_UNUSED_KEEP: retained from the NeurSim layout derivation for future region-height checks.
     double heightRegionP, heightRegionN;
     int numFoldedPMOS = 1, numFoldedNMOS = 1;
 
     // 1.4 update: add GAA - related variables
-    int NumPSheet=0;
-    int NumNSheet=0;
+    // NSCACHE_UNUSED_KEEP: outer sheet counters kept as breadcrumbs; active counters are scoped below.
+    // int NumPSheet=0;
+    // int NumNSheet=0;
     double maxNumPSheet=0;
     double maxNumNSheet=0;
 
@@ -409,6 +411,8 @@ double CalculateGateArea(
 
     *width = MAX(widthRegionN, widthRegionP);
     *height = heightTransistorRegion;	// Fixed standard cell height
+    (void)heightRegionP;
+    (void)heightRegionN;
 
     return (*width)*(*height);
 }
@@ -537,8 +541,9 @@ void CalculateGateCapacitance(
 		if (capInput)
 			*(capInput) = CalculateGateCap(widthNMOS, tech) + CalculateGateCap(widthPMOS, tech);
 	} else {
-		int speciallayout = 0;
-    if (heightTransistorRegion != tech.featureSize *MAX_TRANSISTOR_HEIGHT) speciallayout = 1;
+		// NSCACHE_UNUSED_KEEP: retained for future special-layout capacitance handling.
+		// int speciallayout = 0;
+    // if (heightTransistorRegion != tech.featureSize *MAX_TRANSISTOR_HEIGHT) speciallayout = 1;
 
 
 	if (capInput){
@@ -599,9 +604,10 @@ void CalculateGateCapacitance(
 	    
 		
 		// 1.4 update: add GAA-related parameters
-        int NumPSheet;
-        int NumNSheet;
-        int maxNumSheet;
+        // NSCACHE_UNUSED_KEEP: outer sheet counters kept as breadcrumbs; active counters are scoped below.
+        // int NumPSheet;
+        // int NumNSheet;
+        // int maxNumSheet;
         int maxNumPSheet; 
         int maxNumNSheet; 
 
@@ -1179,7 +1185,12 @@ double CalculateWireResistance_M0(
 		return(alphaScatter * resistivity / (wireThickness - barrierThickness - dishingThickness)
 			/ (wireWidth - 2 * barrierThickness));
 	} else {
-		double Metal0, Metal1, wirewidth, barrierthickness, featuresize;
+		double Metal0 = wireWidth * 1e9;
+		double Metal1 = wireWidth * 1e9;
+		double wirewidth = wireWidth * 1e9;
+		double barrierthickness = barrierThickness;
+		// NSCACHE_UNUSED_KEEP: feature-size fallback retained for custom wire tables.
+		double featuresize = wireWidth;
 		switch (tech.featureSizeInNano){
 			case 130: 	Metal0=175; Metal1=175; wirewidth=175; barrierthickness=10.0e-9; featuresize = wirewidth*1e-9; break;  
 			case 90: 	Metal0=110; Metal1=110; wirewidth=110; barrierthickness=10.0e-9; featuresize = wirewidth*1e-9; break;  
@@ -1197,6 +1208,7 @@ double CalculateWireResistance_M0(
 			case -1:	break;	
 			default:	exit(-1); puts("Wire width out of range"); 
 		}
+		(void)featuresize;
 
 		double AR, Rho;
 		// 1.4 update: wirewidth
@@ -1324,9 +1336,10 @@ double CalculateWireResistance_M0(
 
 		Rho_Metal1 = Rho_Metal1 * 1 / (1- ( (2*AR_Metal1*Metal1 + Metal1)*barrierthickness / (AR_Metal1*pow(Metal1,2) ) ));
 
-		double Metal0_unitwireresis, Metal1_unitwireresis;
+		double Metal0_unitwireresis;
 		Metal0_unitwireresis =  Rho_Metal0 / ( Metal0*1e-9 * Metal0*1e-9 * AR_Metal0 );
-		Metal1_unitwireresis =  Rho_Metal1 / ( Metal1*1e-9 * Metal1*1e-9 * AR_Metal1 );
+		// NSCACHE_UNUSED_KEEP: retained for paired M0/MX wire calibration.
+		// double Metal1_unitwireresis =  Rho_Metal1 / ( Metal1*1e-9 * Metal1*1e-9 * AR_Metal1 );
 
 		return Metal0_unitwireresis;
 	}
@@ -1339,7 +1352,12 @@ double CalculateWireResistance_MX(
 		return(alphaScatter * resistivity / (wireThickness - barrierThickness - dishingThickness)
 			/ (wireWidth - 2 * barrierThickness));
 	} else {
-		double Metal0, Metal1, wirewidth, barrierthickness, featuresize;
+		double Metal0 = wireWidth * 1e9;
+		double Metal1 = wireWidth * 1e9;
+		double wirewidth = wireWidth * 1e9;
+		double barrierthickness = barrierThickness;
+		// NSCACHE_UNUSED_KEEP: feature-size fallback retained for custom wire tables.
+		double featuresize = wireWidth;
 		switch (tech.featureSizeInNano){
 			case 130: 	Metal0=175; Metal1=175; wirewidth=175; barrierthickness=10.0e-9; featuresize = wirewidth*1e-9; break;  
 			case 90: 	Metal0=110; Metal1=110; wirewidth=110; barrierthickness=10.0e-9; featuresize = wirewidth*1e-9; break;  
@@ -1357,6 +1375,7 @@ double CalculateWireResistance_MX(
 			case -1:	break;	
 			default:	exit(-1); puts("Wire width out of range"); 
 		}
+		(void)featuresize;
 
 		double AR, Rho;
 		// 1.4 update: wirewidth
@@ -1484,8 +1503,9 @@ double CalculateWireResistance_MX(
 
 		Rho_Metal1 = Rho_Metal1 * 1 / (1- ( (2*AR_Metal1*Metal1 + Metal1)*barrierthickness / (AR_Metal1*pow(Metal1,2) ) ));
 
-		double Metal0_unitwireresis, Metal1_unitwireresis;
-		Metal0_unitwireresis =  Rho_Metal0 / ( Metal0*1e-9 * Metal0*1e-9 * AR_Metal0 );
+		// NSCACHE_UNUSED_KEEP: retained for paired M0/MX wire calibration.
+		// double Metal0_unitwireresis =  Rho_Metal0 / ( Metal0*1e-9 * Metal0*1e-9 * AR_Metal0 );
+		double Metal1_unitwireresis;
 		Metal1_unitwireresis =  Rho_Metal1 / ( Metal1*1e-9 * Metal1*1e-9 * AR_Metal1 );
 
 		return Metal1_unitwireresis;
@@ -1497,10 +1517,11 @@ void EnlargeSize(double *widthNMOS, double *widthPMOS, double heightTransistorRe
     double	ratio = *widthPMOS / (*widthPMOS + *widthNMOS);
     double maxWidthPMOS, maxWidthNMOS;
     int maxNumPFin, maxNumNFin;	/* Max number of fins for the specified cell height */
-    double unitWidthRegionP, unitWidthRegionN;
-    double widthRegionP, widthRegionN;
-    double heightRegionP, heightRegionN;
-    int numFoldedPMOS = 1, numFoldedNMOS = 1;
+    // NSCACHE_UNUSED_KEEP: retained for future region-aware EnlargeSize logic.
+    // double unitWidthRegionP, unitWidthRegionN;
+    // double widthRegionP, widthRegionN;
+    // double heightRegionP, heightRegionN;
+    // int numFoldedPMOS = 1, numFoldedNMOS = 1;
 
     double temp_widthPMOS = *widthPMOS;
     double temp_widthNMOS = *widthNMOS;

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -99,7 +99,7 @@ double CalculateGateArea(
 	
     double	ratio = widthPMOS / (widthPMOS + widthNMOS);
     double maxWidthPMOS, maxWidthNMOS;
-    int maxNumPFin, maxNumNFin;	/* Max number of fins for the specified cell height */
+    int maxNumPFin = 0, maxNumNFin = 0;	/* Max number of fins for the specified cell height */
     double unitWidthRegionP, unitWidthRegionN;
     double widthRegionP, widthRegionN;
     double heightRegionP, heightRegionN;
@@ -193,11 +193,15 @@ double CalculateGateArea(
             maxNumPFin =  maxNumNFin = tech.max_fin_num;
         } else if (tech.featureSize == 2 * 1e-9) {
             maxNumPSheet= maxNumNSheet = tech.max_fin_per_GAA;
-        } else if (tech.featureSize == 1 * 1e-9) {
-            maxNumPSheet= maxNumNSheet = tech.max_fin_per_GAA;
-        } 
+	        } else if (tech.featureSize == 1 * 1e-9) {
+	            maxNumPSheet= maxNumNSheet = tech.max_fin_per_GAA;
+	        } else if (tech.featureSize > 2 * 1e-9) {
+	            maxNumPFin = maxNumNFin = tech.max_fin_num;
+	        } else {
+	            maxNumPSheet = maxNumNSheet = tech.max_fin_per_GAA;
+	        }
 
-        }
+	        }
 
         else {
 
@@ -214,9 +218,13 @@ double CalculateGateArea(
             maxNumPFin = maxNumNFin = (floor)( ( (heightTransistorRegion -  (double) MIN_GAP_BET_P_AND_N_DIFFS_3nm * tech.featureSize -  (double) OUTER_HEIGHT_REGION_3nm * tech.featureSize) + tech.PitchFin ) / 2.0 / (tech.widthFin + tech.PitchFin) );
         } else if (tech.featureSize == 2 * 1e-9) {
             maxNumPSheet= maxNumNSheet =  (floor)( ( (heightTransistorRegion -  (double) MIN_GAP_BET_P_AND_N_DIFFS_2nm * tech.featureSize -  (double) OUTER_HEIGHT_REGION_2nm * tech.featureSize) + tech.PitchFin ) / 2.0 / (tech.widthFin + tech.PitchFin) );
-        } else if (tech.featureSize == 1 * 1e-9) {
-            maxNumPSheet= maxNumNSheet = (floor)( ( (heightTransistorRegion -  (double) MIN_GAP_BET_P_AND_N_DIFFS_1nm * tech.featureSize -  (double) OUTER_HEIGHT_REGION_1nm* tech.featureSize) + tech.PitchFin ) / 2.0 / (tech.widthFin + tech.PitchFin) );
-        } 
+	        } else if (tech.featureSize == 1 * 1e-9) {
+	            maxNumPSheet= maxNumNSheet = (floor)( ( (heightTransistorRegion -  (double) MIN_GAP_BET_P_AND_N_DIFFS_1nm * tech.featureSize -  (double) OUTER_HEIGHT_REGION_1nm* tech.featureSize) + tech.PitchFin ) / 2.0 / (tech.widthFin + tech.PitchFin) );
+	        } else if (tech.featureSize > 2 * 1e-9) {
+	            maxNumPFin = maxNumNFin = tech.max_fin_num;
+	        } else {
+	            maxNumPSheet = maxNumNSheet = tech.max_fin_per_GAA;
+	        }
             
 
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,6 +54,7 @@ MemCell **sweepCells;
 int numRowMat, numColumnMat;
 
 void applyConstraint();
+void initializeTechnology(Technology *target, int processNode, DeviceRoadmap deviceRoadmap);
 int nvsim(ofstream& outputFile, string inputFileName, long long& numSolution, Result *bestDataResults, Result *bestTagResults);
 
 void tsvVerif(InputParameter *inputParameter)
@@ -104,7 +105,7 @@ void tsvVerif(InputParameter *inputParameter)
                         alpha = (techNodes[node] - 14.0) / 8;
 					} else if (techNodes[node] >= 10) { // 10 nm < technology node <= 14 nm
                         techHigh.Initialize(14, inputParameter->deviceRoadmap, inputParameter);
-                        alpha = (techNodes[node] - 14.0) / 4;
+                        alpha = (techNodes[node] - 10.0) / 4;
 					} else if (techNodes[node] >= 7) { // 7 nm < technology node <= 10 nm
                         techHigh.Initialize(10, inputParameter->deviceRoadmap, inputParameter);
                         alpha = (techNodes[node] - 7.0) / 3;
@@ -173,60 +174,11 @@ int main(int argc, char *argv[])
     //tsvVerif(inputParameter);
 
 	tech = new Technology();
-	tech->Initialize(inputParameter->processNode, inputParameter->deviceRoadmap, inputParameter);
+	initializeTechnology(tech, inputParameter->processNode, inputParameter->deviceRoadmap);
 
 	/* NS-Cache Warning for New Users for NeuroSim Infrastructure */
 	if (inputParameter->temperature > 300 && inputParameter->processNode < 22) cout << "WARNING: NeuroSim sub-22nm nodes on-current only calibrated for room temperature. [V.1.0]\n" << endl;
 
-	Technology techHigh;
-	double alpha = 0;
-	if (inputParameter->processNode > 200){
-		// TO-DO: technology node > 200 nm
-	} else if (inputParameter->processNode > 120) { // 120 nm < technology node <= 200 nm
-		techHigh.Initialize(200, inputParameter->deviceRoadmap, inputParameter);
-		alpha = (inputParameter->processNode - 120.0) / 60;
-	} else if (inputParameter->processNode > 90) { // 90 nm < technology node <= 120 nm
-		techHigh.Initialize(120, inputParameter->deviceRoadmap, inputParameter);
-		alpha = (inputParameter->processNode - 90.0) / 30;
-	} else if (inputParameter->processNode > 65) { // 65 nm < technology node <= 90 nm
-		techHigh.Initialize(90, inputParameter->deviceRoadmap, inputParameter);
-		alpha = (inputParameter->processNode - 65.0) / 25;
-	} else if (inputParameter->processNode > 45) { // 45 nm < technology node <= 65 nm
-		techHigh.Initialize(65, inputParameter->deviceRoadmap, inputParameter);
-		alpha = (inputParameter->processNode - 45.0) / 20;
-	} else if (inputParameter->processNode >= 32) { // 32 nm < technology node <= 45 nm
-		techHigh.Initialize(45, inputParameter->deviceRoadmap, inputParameter);
-		alpha = (inputParameter->processNode - 32.0) / 13;
-	} else if (inputParameter->processNode >= 22) { // 22 nm < technology node <= 32 nm
-		techHigh.Initialize(32, inputParameter->deviceRoadmap, inputParameter);
-		alpha = (inputParameter->processNode - 22.0) / 10;
-	} else if (inputParameter->processNode >= 14) { // 14 nm < technology node <= 22 nm
-		techHigh.Initialize(22, inputParameter->deviceRoadmap, inputParameter);
-		alpha = (inputParameter->processNode - 14.0) / 8;
-	} else if (inputParameter->processNode >= 10) { // 10 nm < technology node <= 14 nm
-		techHigh.Initialize(14, inputParameter->deviceRoadmap, inputParameter);
-		alpha = (inputParameter->processNode - 14.0) / 4;
-	} else if (inputParameter->processNode >= 7) { // 7 nm < technology node <= 10 nm
-		techHigh.Initialize(10, inputParameter->deviceRoadmap, inputParameter);
-		alpha = (inputParameter->processNode - 7.0) / 3;
-	} else if (inputParameter->processNode >= 5) { // 5 nm < technology node <= 7 nm
-		techHigh.Initialize(7, inputParameter->deviceRoadmap, inputParameter);
-		alpha = (inputParameter->processNode - 5.0) / 2;
-	} else if (inputParameter->processNode >= 3) { // 3 nm < technology node <= 5 nm
-		techHigh.Initialize(5, inputParameter->deviceRoadmap, inputParameter);
-		alpha = (inputParameter->processNode - 3.0) / 2;
-	} else if (inputParameter->processNode >= 2) { // 2 nm < technology node <= 3 nm
-		techHigh.Initialize(3, inputParameter->deviceRoadmap, inputParameter);
-		alpha = (inputParameter->processNode - 2.0) / 1;
-	} else if (inputParameter->processNode >= 1) { // 1 nm < technology node <= 2 nm
-		techHigh.Initialize(2, inputParameter->deviceRoadmap, inputParameter);
-		alpha = (inputParameter->processNode - 1.0) / 1;
-	} else {
-		//TO-DO: technology node < 22 nm
-	}
-
-	tech->InterpolateWith(techHigh, alpha);
-	
     /* Open output file for full_exploration. */
     ofstream outputFile;
 	string outputFileName;
@@ -272,9 +224,9 @@ int main(int argc, char *argv[])
         /* In most cases device technology is the same as the peripheral technology. */
         devtech = tech;
 
-        if (cell->memCellType == eDRAM && false) {
+        if (cell->memCellType == eDRAM) {
             devtech = new Technology();
-            devtech->Initialize(inputParameter->processNode, EDRAM, inputParameter);
+            initializeTechnology(devtech, inputParameter->processNode, EDRAM);
         }
 
         if (cellIdx == 0) // Print once only
@@ -292,7 +244,7 @@ int main(int argc, char *argv[])
             totalSolutions += solutions;
         }
 
-        if (cell->memCellType == eDRAM && false) {
+        if (cell->memCellType == eDRAM) {
             delete devtech;
         }
     }
@@ -366,6 +318,63 @@ int main(int argc, char *argv[])
 	}
 
 	return 0;
+}
+
+void initializeTechnology(Technology *target, int processNode, DeviceRoadmap deviceRoadmap)
+{
+	target->Initialize(processNode, deviceRoadmap, inputParameter);
+
+	Technology techHigh;
+	double alpha = 0;
+	bool interpolate = true;
+	if (processNode > 200){
+		interpolate = false;
+	} else if (processNode > 120) { // 120 nm < technology node <= 200 nm
+		techHigh.Initialize(200, deviceRoadmap, inputParameter);
+		alpha = (processNode - 120.0) / 60;
+	} else if (processNode > 90) { // 90 nm < technology node <= 120 nm
+		techHigh.Initialize(120, deviceRoadmap, inputParameter);
+		alpha = (processNode - 90.0) / 30;
+	} else if (processNode > 65) { // 65 nm < technology node <= 90 nm
+		techHigh.Initialize(90, deviceRoadmap, inputParameter);
+		alpha = (processNode - 65.0) / 25;
+	} else if (processNode > 45) { // 45 nm < technology node <= 65 nm
+		techHigh.Initialize(65, deviceRoadmap, inputParameter);
+		alpha = (processNode - 45.0) / 20;
+	} else if (processNode >= 32) { // 32 nm < technology node <= 45 nm
+		techHigh.Initialize(45, deviceRoadmap, inputParameter);
+		alpha = (processNode - 32.0) / 13;
+	} else if (processNode >= 22) { // 22 nm < technology node <= 32 nm
+		techHigh.Initialize(32, deviceRoadmap, inputParameter);
+		alpha = (processNode - 22.0) / 10;
+	} else if (processNode >= 14) { // 14 nm < technology node <= 22 nm
+		techHigh.Initialize(22, deviceRoadmap, inputParameter);
+		alpha = (processNode - 14.0) / 8;
+	} else if (processNode >= 10) { // 10 nm < technology node <= 14 nm
+		techHigh.Initialize(14, deviceRoadmap, inputParameter);
+		alpha = (processNode - 10.0) / 4;
+	} else if (processNode >= 7) { // 7 nm < technology node <= 10 nm
+		techHigh.Initialize(10, deviceRoadmap, inputParameter);
+		alpha = (processNode - 7.0) / 3;
+	} else if (processNode >= 5) { // 5 nm < technology node <= 7 nm
+		techHigh.Initialize(7, deviceRoadmap, inputParameter);
+		alpha = (processNode - 5.0) / 2;
+	} else if (processNode >= 3) { // 3 nm < technology node <= 5 nm
+		techHigh.Initialize(5, deviceRoadmap, inputParameter);
+		alpha = (processNode - 3.0) / 2;
+	} else if (processNode >= 2) { // 2 nm < technology node <= 3 nm
+		techHigh.Initialize(3, deviceRoadmap, inputParameter);
+		alpha = (processNode - 2.0) / 1;
+	} else if (processNode >= 1) { // 1 nm < technology node <= 2 nm
+		techHigh.Initialize(2, deviceRoadmap, inputParameter);
+		alpha = (processNode - 1.0) / 1;
+	} else {
+		interpolate = false;
+	}
+
+	if (interpolate) {
+		target->InterpolateWith(techHigh, alpha);
+	}
 }
 
 int nvsim(ofstream& outputFile, string inputFileName, long long& numSolution, Result *bestDataResults, Result *bestTagResults)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -248,6 +248,7 @@ int main(int argc, char *argv[])
             delete devtech;
         }
     }
+    cout << "[Info] Cell exploration failures: " << failures << " / " << numCellTypes << endl;
 
     /* Compare against results from previous cell types. */
     if (inputParameter->optimizationTarget == full_exploration 
@@ -441,7 +442,7 @@ int nvsim(ofstream& outputFile, string inputFileName, long long& numSolution, Re
 			}
 			capacity = (long long)inputParameter->capacity * 8 / inputParameter->wordWidth * blockSize;
 			associativity = inputParameter->associativity;
-			CALCULATE(tagBank, tag);
+			CALCULATE(tagBank, MemoryType::tag);
             numDesigns++;
 			if (!tagBank->invalid) {
 				Result tempResult;
@@ -462,7 +463,7 @@ int nvsim(ofstream& outputFile, string inputFileName, long long& numSolution, Re
 						(bool)isLocalWireLowSwing);
 				for (int i = 0; i < (int)full_exploration; i++) {
 					LOAD_GLOBAL_WIRE(bestTagResults[i]);
-					TRY_AND_UPDATE(bestTagResults[i], tag);
+					TRY_AND_UPDATE(bestTagResults[i], MemoryType::tag);
 				}
 			}
 			/* refine global wire type */
@@ -472,7 +473,7 @@ int nvsim(ofstream& outputFile, string inputFileName, long long& numSolution, Re
 						(bool)isGlobalWireLowSwing);
 				for (int i = 0; i < (int)full_exploration; i++) {
 					LOAD_LOCAL_WIRE(bestTagResults[i]);
-					TRY_AND_UPDATE(bestTagResults[i], tag);
+					TRY_AND_UPDATE(bestTagResults[i], MemoryType::tag);
 				}
 			}
 		}
@@ -532,7 +533,7 @@ int nvsim(ofstream& outputFile, string inputFileName, long long& numSolution, Re
         //    // Require at least 32x32 subarrays.
         //    continue;
         //}
-		CALCULATE(dataBank, data);
+		CALCULATE(dataBank, MemoryType::data);
         numDesigns++;
 		if (!dataBank->invalid) {
 			Result tempResult;
@@ -558,7 +559,7 @@ int nvsim(ofstream& outputFile, string inputFileName, long long& numSolution, Re
 					(bool)isLocalWireLowSwing);
 			for (int i = 0; i < (int)full_exploration; i++) {
 				LOAD_GLOBAL_WIRE(bestDataResults[i]);
-				TRY_AND_UPDATE(bestDataResults[i], data);
+				TRY_AND_UPDATE(bestDataResults[i], MemoryType::data);
 			}
 			if (inputParameter->optimizationTarget == full_exploration && !inputParameter->isPruningEnabled) {
 				OUTPUT_TO_FILE;
@@ -571,7 +572,7 @@ int nvsim(ofstream& outputFile, string inputFileName, long long& numSolution, Re
 					(bool)isGlobalWireLowSwing);
 			for (int i = 0; i < (int)full_exploration; i++) {
 				LOAD_LOCAL_WIRE(bestDataResults[i]);
-				TRY_AND_UPDATE(bestDataResults[i], data);
+				TRY_AND_UPDATE(bestDataResults[i], MemoryType::data);
 			}
 			if (inputParameter->optimizationTarget == full_exploration && !inputParameter->isPruningEnabled) {
 				OUTPUT_TO_FILE;
@@ -620,6 +621,12 @@ int nvsim(ofstream& outputFile, string inputFileName, long long& numSolution, Re
 						break;
 					case write_edp_optimized:
 						pruningResults[i][j][k]->limitWriteEdp = bestDataResults[j].bank->writeLatency * bestDataResults[j].bank->writeDynamicEnergy * (1 + (k + 1.0) / 10);
+						break;
+					case read_bandwidth_optimized:
+						pruningResults[i][j][k]->limitReadBandwidth = bestDataResults[j].getReadBandwidth() / (1 + (k + 1.0) / 10);
+						break;
+					case write_bandwidth_optimized:
+						pruningResults[i][j][k]->limitWriteBandwidth = bestDataResults[j].getWriteBandwidth() / (1 + (k + 1.0) / 10);
 						break;
 					case area_optimized:
 						pruningResults[i][j][k]->limitArea = bestDataResults[j].bank->area * (1 + (k + 1.0) / 10);
@@ -675,7 +682,7 @@ int nvsim(ofstream& outputFile, string inputFileName, long long& numSolution, Re
 				/* To aggressive partitioning */
 				continue;
 			}
-			CALCULATE(dataBank, data);
+			CALCULATE(dataBank, MemoryType::data);
             numDesigns++;
 			if (!dataBank->invalid && dataBank->readLatency <= allowedDataReadLatency && dataBank->writeLatency <= allowedDataWriteLatency
 					&& dataBank->readDynamicEnergy <= allowedDataReadDynamicEnergy && dataBank->writeDynamicEnergy <= allowedDataWriteDynamicEnergy

--- a/src/typedef.h
+++ b/src/typedef.h
@@ -124,9 +124,11 @@ enum OptimizationTarget
 	write_energy_optimized = 3,
 	read_edp_optimized = 4,
 	write_edp_optimized = 5,
-	leakage_optimized = 6,
-	area_optimized = 7,
-	full_exploration = 8
+	read_bandwidth_optimized = 6,
+	write_bandwidth_optimized = 7,
+	leakage_optimized = 8,
+	area_optimized = 9,
+	full_exploration = 10
 };
 
 enum CacheAccessMode


### PR DESCRIPTION
1. Fixed the broken eDRAM technology selection path so eDRAM memory-device technology uses the intended memory technology without disturbing logic technology.

2. fixed its virtual PrintProperty() warning.

3. Cleaned up compile warnings from unused or stale variables (retained code with NSCACHE_UNUSED_KEEP)

4. Added a default fallback for NeuroSim custom wire-width handling

5. Added a cell exploration failure printout:
Cell exploration failures: X / Y

6. Fixed WSL/Ubuntu ambiguous data enum issues by qualifying memory type references as MemoryType::data and MemoryType::tag.

7. Added read/write bandwidth optimization targets:
ReadBandwidth and WriteBandwidth.

8. Added bandwidth-aware pruning limits for full-exploration pruning paths.

9. Compared sampled configs against main; SRAM, eDRAM, and gain-cell cache numiecal outputs